### PR TITLE
Fix http link for favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <title>Moulay Anwar Sounny-Slitine, PhD</title>
 
-  <link rel="icon" href="http://sounny.github.io/favicon.png">
+  <link rel="icon" href="https://sounny.github.io/favicon.png">
   <!-- Font Awesome Icons -->
   <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
## Summary
- use `https` for the favicon

## Testing
- `grep -n favicon index.html`

------
https://chatgpt.com/codex/tasks/task_e_6842fec1ef0c8327855715fdaaae58ab