### PR TITLE
Fix Android Studio typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,8 +259,8 @@
 		<div class="card text-center" style="width: 18rem;">
 	  <img class="card-img-top" src="img/cards/asm.png" alt="Card image cap">
 	  <div class="card-body">
-		<h5 class="card-title">Andriod Studio on a Mac</h5>
-		<p class="card-text">How to install Andriod Studio on a mac</p>
+                <h5 class="card-title">Android Studio on a Mac/PC</h5>
+                <p class="card-text">How to install Android Studio on a mac</p>
 		<a href="https://www.youtube.com/watch?v=wgrEEnGAm7s" class="btn btn-primary">YouTube Video</a>
 	  </div>	  
 	</div>
@@ -269,8 +269,8 @@
 		<div class="card text-center" style="width: 18rem;">
 	  <img class="card-img-top" src="img/cards/aspc.png" alt="Card image cap">
 	  <div class="card-body">
-		<h5 class="card-title">Andriod Studio on a PC</h5>
-		<p class="card-text">How to install Andriod Studio on a PC</p>
+                <h5 class="card-title">Android Studio on a Mac/PC</h5>
+                <p class="card-text">How to install Android Studio on a PC</p>
 		<a href="https://www.youtube.com/watch?v=ZEj5Ar42xXs" class="btn btn-primary">YouTube Video</a>
 	  </div>	  
 	</div>


### PR DESCRIPTION
## Summary
- fix typo in Android Studio card titles and descriptions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842febc9b148327842749146de5a8c1