### PR TITLE
Add Mapbox and QGIS to must-have apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,20 @@
           </div>
         </div>
 		  
+        <div class="col-lg-3 col-md-6 text-center">
+          <div class="mt-5">
+            <i class="fas fa-4x fa-map-marked-alt text-primary mb-4"></i>
+            <h3 class="h4 mb-2">Mapbox</h3>
+            <p class="text-muted mb-0">Tools for custom online maps and geospatial APIs. <a href="https://www.mapbox.com/">mapbox.com</a></p>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-6 text-center">
+          <div class="mt-5">
+            <i class="fas fa-4x fa-map text-primary mb-4"></i>
+            <h3 class="h4 mb-2">QGIS</h3>
+            <p class="text-muted mb-0">Open source desktop GIS for geospatial analysis. <a href="https://qgis.org/">qgis.org</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add Mapbox and QGIS recommendations to the "Must Haves" app list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844909bd3c48327b9d802e8ed76c0ba