### PR TITLE
Add GIS toolbox section

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
               <a class="nav-link js-scroll-trigger" href="#about">About</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link js-scroll-trigger" href="#gis">GIS</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#lessons">Lessons</a>
             </li>
             <li class="nav-item">
@@ -150,14 +153,51 @@
               applications. The only thing limiting you is developing your
               skillsets. Look below and learn how to digital explore the world.
             </p>
-            <a class="btn btn-light btn-xl js-scroll-trigger" href="#lessons"
-              >Let's Learn!</a
+            <a class="btn btn-light btn-xl js-scroll-trigger" href="#gis"
+              >Let's Explore</a
             >
           </div>
         </div>
       </div>
     </section>
 
+    <!-- GIS Section -->
+    <section class="page-section" id="gis">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-8 text-center">
+            <h2 class="mt-0">GIS Toolbox</h2>
+            <hr class="divider my-4" />
+            <p class="text-muted mb-5">
+              Collection of WebGIS tools for geospatial analysis.
+            </p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-search-location fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">AGOL Geocoder</h3>
+              <a href="https://sounny.github.io/geocoder/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-globe fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">OSM Geocoder</h3>
+              <a href="https://sounny.github.io/osmgeocoder/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-flag-usa fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">US Cartogram</h3>
+              <a href="https://sounny.github.io/cartogram/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
     <!-- Portfolio Section -->
     <section id="lessons">
       <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- add link to new GIS section in navigation
- change 'Let's Learn' button to 'Let's Explore' and link to GIS section
- introduce GIS toolbox section with links to web-based geocoder and cartogram tools

## Testing
- `npm install`
- `npx gulp`

------
https://chatgpt.com/codex/tasks/task_e_6847cade73bc832783e356c318b2391a