### PR TITLE
Add Mercator puzzle to GeoApps

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,13 @@
               <a href="https://sounny.github.io/neuralnet/" class="btn btn-primary mt-3">Launch</a>
             </div>
           </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-puzzle-piece fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">Mercator Puzzle</h3>
+              <a href="https://sounny.github.io/mercatorpuzzle/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add link to the Mercator Puzzle map tool

## Testing
- `npm run build` *(fails: missing script)*
- `npx gulp build` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9f98ea88327bd68756ba46146d1