### PR TITLE
Add Leaflet GeoSearch link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,6 +1033,16 @@
               </p>
             </div>
           </div>
+          <div class="col-lg-3 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-4x fa-search-location text-primary mb-4"></i>
+              <h3 class="h4 mb-2">Leaflet GeoSearch</h3>
+              <p class="text-muted mb-0">
+                Plugin for searching addresses and places in Leaflet maps.
+                <a href="https://smeijer.github.io/leaflet-geosearch/">leaflet-geosearch</a>
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add Leaflet GeoSearch website to the Must Haves section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a8cf14380832782de0d93232e66d8