### PR TITLE
Add ColorBrewer GIS tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,13 @@
               <a href="https://sounny.github.io/leaflet/" class="btn btn-primary mt-3">Launch</a>
             </div>
           </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-palette fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">ColorBrewer</h3>
+              <a href="https://sounny.github.io/colorbrewer/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add ColorBrewer tool link in GIS Toolbox section of homepage

## Testing
- `npm install`
- `npx gulp build`


------
https://chatgpt.com/codex/tasks/task_e_687f985baf10832788cdd3a629fcbedd