### PR TITLE
Fix mobile spacing between GIS and GeoApps

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
     </section>
 
     <!-- GIS Section -->
-    <section class="page-section bg-dark text-white pb-0" id="gis">
+    <section class="page-section bg-dark text-white pb-4 pb-lg-0" id="gis">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-lg-8 text-center">
@@ -216,7 +216,7 @@
       </div>
     </section>
     <!-- GeoApps Section -->
-    <section class="page-section bg-dark text-white pt-0" id="geoapps">
+    <section class="page-section bg-dark text-white pt-4 pt-lg-0" id="geoapps">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-lg-8 text-center">


### PR DESCRIPTION
## Summary
- add responsive bottom padding to the GIS section
- add responsive top padding to the GeoApps section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fd1a0d99c8327914a46d637426c7c