### PR TITLE
Separate GIS and GeoApps sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
     </section>
 
     <!-- GIS Section -->
-    <section class="page-section bg-dark text-white pb-4 pb-lg-0" id="gis">
+    <section class="page-section bg-dark text-white" id="gis">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-lg-8 text-center">
@@ -216,7 +216,7 @@
       </div>
     </section>
     <!-- GeoApps Section -->
-    <section class="page-section bg-dark text-white pt-4 pt-lg-0" id="geoapps">
+    <section class="page-section bg-dark text-white" id="geoapps">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-lg-8 text-center">


### PR DESCRIPTION
## Summary
- keep default section padding for GIS and GeoApps so they no longer appear as a single block

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68810910f9308327a09e745fd117ef64