### PR TITLE
Add color wheel tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,16 @@
               <a href="https://sounny.github.io/pdfcompressor/" class="btn btn-primary mt-3">Launch</a>
             </div>
           </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-palette fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">Color Wheel</h3>
+              <p class="text-white mb-0">
+                Apply color theory to craft harmonious swatches.
+              </p>
+              <a href="https://sounny.github.io/colorwheel/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add Color Wheel tool to the website's Tools section to help users apply color theory in their swatches.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf3d1ae70c8327801c49bb27ecedf4