### PR TITLE
Add EEFA open access book to resources section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,6 +1151,16 @@
           </div>
           <div class="col-lg-3 col-md-6 text-center">
             <div class="mt-5">
+              <i class="fas fa-4x fa-book-open text-primary mb-4"></i>
+              <h3 class="h4 mb-2">EEFA Book</h3>
+              <p class="text-muted mb-0">
+                Open access guide to learning Google Earth Engine.
+                <a href="https://www.eefabook.org/go-to-the-book.html">eefabook.org</a>
+              </p>
+            </div>
+          </div>
+          <div class="col-lg-3 col-md-6 text-center">
+            <div class="mt-5">
               <i class="fas fa-4x fa-map text-primary mb-4"></i>
               <h3 class="h4 mb-2">QGIS</h3>
               <p class="text-muted mb-0">


### PR DESCRIPTION
## Summary
- add the EEFA open access Google Earth Engine book to the Must Haves resources grid

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d187a413c08327bdc636da4bb33a88