### PR TITLE
Add Ohm's Law calculator link to tools section

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,16 @@
               <a href="https://sounny.github.io/colorwheel/" class="btn btn-primary mt-3">Launch</a>
             </div>
           </div>
+          <div class="col-lg-4 col-md-6 text-center">
+            <div class="mt-5">
+              <i class="fas fa-bolt fa-4x text-primary mb-4"></i>
+              <h3 class="h4 mb-2">Ohm's Law Calculator</h3>
+              <p class="text-white mb-0">
+                Explore voltage, current, and resistance relationships instantly.
+              </p>
+              <a href="https://sounny.github.io/ohm/" class="btn btn-primary mt-3">Launch</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a tools card for the new Ohm's Law Calculator web app
- link the button to https://sounny.github.io/ohm/

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68dd35b401d88327b4c446484fc3198b